### PR TITLE
GetPlays() add filters

### DIFF
--- a/instruqt/play.go
+++ b/instruqt/play.go
@@ -56,12 +56,10 @@ type PlayReports struct {
 // PlayReport represents the data structure for a single play report on Instruqt.
 type PlayReport struct {
 	Id    string // The unique identifier for the play report.
-	Track struct {
-		Id string // The unique identifier of the track associated with the play.
-	}
-	TrackInvite struct {
-		Id string // The unique identifier of the track invite associated with the play.
-	}
+	Track Track  // The track played.
+
+	TrackInvite TrackInvite // The optional Track invite associated to the play.
+
 	User User // The user that played the play.
 
 	CompletionPercent   float64   // The percentage of the play that has been completed.

--- a/instruqt/play.go
+++ b/instruqt/play.go
@@ -15,6 +15,7 @@
 package instruqt
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/shurcooL/graphql"
@@ -88,6 +89,44 @@ type PlayReport struct {
 	}
 }
 
+// GetPlaysOption defines a function type that modifies PlayReportFilter
+type GetPlaysOption func(*PlayReportFilter)
+
+// WithTrackIDs sets the TrackIDs filter
+func WithTrackIDs(ids ...string) GetPlaysOption {
+	return func(f *PlayReportFilter) {
+		f.TrackIDs = ids
+	}
+}
+
+// WithTrackInviteIDs sets the TrackInviteIDs filter
+func WithTrackInviteIDs(ids ...string) GetPlaysOption {
+	return func(f *PlayReportFilter) {
+		f.TrackInviteIDs = ids
+	}
+}
+
+// WithTags sets the Tags filter
+func WithTags(tags ...string) GetPlaysOption {
+	return func(f *PlayReportFilter) {
+		f.Tags = tags
+	}
+}
+
+// WithUserIDs sets the UserIDs filter
+func WithUserIDs(ids ...string) GetPlaysOption {
+	return func(f *PlayReportFilter) {
+		f.UserIDs = ids
+	}
+}
+
+// WithPlayType sets the PlayType filter
+func WithPlayType(pt PlayType) GetPlaysOption {
+	return func(f *PlayReportFilter) {
+		f.PlayType = pt
+	}
+}
+
 // GetPlays retrieves a list of play reports from Instruqt for the specified team,
 // within a given date range, and using pagination parameters.
 //
@@ -96,47 +135,58 @@ type PlayReport struct {
 //   - to: The end date of the date range filter.
 //   - take: The number of play reports to retrieve in one call.
 //   - skip: The number of play reports to skip before starting to retrieve.
-//   - filters: Optional filters to apply to the query.
+//   - opts: A variadic number of GetPlaysOption to configure the query.
 //
 // Returns:
 //   - []PlayReport: A list of play reports that match the given criteria.
 //   - int: The total number of play reports available for the given criteria.
 //   - error: Any error encountered while retrieving the play reports.
-func (c *Client) GetPlays(from time.Time, to time.Time, take int, skip int, filters *PlayReportFilter) (plays []PlayReport, totalItems int, err error) {
-	// Initialize the slices as empty to avoid sending `null` to the GraphQL API
-	trackIds := []graphql.String{}
-	trackInviteIds := []graphql.String{}
-	landingPageIds := []graphql.String{}
-	tags := []graphql.String{}
-	userIds := []graphql.String{}
-
-	// If no filters are passed, the function will retrieve all plays (PlayTypeAll) for the given date range.
-	playType := PlayTypeAll
-
-	// Map filters to GraphQL compatible types if they are provided
-	if filters != nil {
-		for _, id := range filters.TrackIDs {
-			trackIds = append(trackIds, graphql.String(id))
-		}
-		for _, inviteID := range filters.TrackInviteIDs {
-			trackInviteIds = append(trackInviteIds, graphql.String(inviteID))
-		}
-		for _, pageID := range filters.LandingPageIDs {
-			landingPageIds = append(landingPageIds, graphql.String(pageID))
-		}
-		for _, tag := range filters.Tags {
-			tags = append(tags, graphql.String(tag))
-		}
-		for _, userID := range filters.UserIDs {
-			userIds = append(userIds, graphql.String(userID))
-		}
-
-		if filters.PlayType != "" {
-			playType = filters.PlayType
-		}
+//
+// GetPlays retrieves play reports with optional filters, ordering, and custom parameters.
+// It accepts a variadic number of GetPlaysOption to configure the query.
+func (c *Client) GetPlays(from time.Time, to time.Time, take int, skip int, opts ...GetPlaysOption) ([]PlayReport, int, error) {
+	// Initialize the filter with default values
+	filters := &PlayReportFilter{
+		TrackIDs:       []string{},
+		TrackInviteIDs: []string{},
+		LandingPageIDs: []string{},
+		Tags:           []string{},
+		UserIDs:        []string{},
+		PlayType:       PlayTypeAll, // Default PlayType
 	}
 
-	// Pass the filters to the GraphQL query variables
+	// Apply each option to modify the filter
+	for _, opt := range opts {
+		opt(filters)
+	}
+
+	// Convert Go types to GraphQL types
+	trackIds := make([]graphql.String, len(filters.TrackIDs))
+	for i, id := range filters.TrackIDs {
+		trackIds[i] = graphql.String(id)
+	}
+
+	trackInviteIds := make([]graphql.String, len(filters.TrackInviteIDs))
+	for i, id := range filters.TrackInviteIDs {
+		trackInviteIds[i] = graphql.String(id)
+	}
+
+	landingPageIds := make([]graphql.String, len(filters.LandingPageIDs))
+	for i, id := range filters.LandingPageIDs {
+		landingPageIds[i] = graphql.String(id)
+	}
+
+	tags := make([]graphql.String, len(filters.Tags))
+	for i, tag := range filters.Tags {
+		tags[i] = graphql.String(tag)
+	}
+
+	userIds := make([]graphql.String, len(filters.UserIDs))
+	for i, id := range filters.UserIDs {
+		userIds[i] = graphql.String(id)
+	}
+
+	// Prepare the variables map for the GraphQL query
 	variables := map[string]interface{}{
 		"teamSlug":       graphql.String(c.TeamSlug),
 		"from":           from,
@@ -148,13 +198,13 @@ func (c *Client) GetPlays(from time.Time, to time.Time, take int, skip int, filt
 		"userIds":        userIds,
 		"take":           graphql.Int(take),
 		"skip":           graphql.Int(skip),
-		"playType":       playType,
+		"playType":       filters.PlayType,
 	}
 
 	var q playQuery
 	if err := c.GraphQLClient.Query(c.Context, &q, variables); err != nil {
-		return plays, 0, err
+		return nil, 0, fmt.Errorf("GraphQL query failed: %w", err)
 	}
 
-	return q.PlayReports.Items, q.TotalItems, nil
+	return q.PlayReports.Items, q.PlayReports.TotalItems, nil
 }

--- a/instruqt/play_test.go
+++ b/instruqt/play_test.go
@@ -44,6 +44,9 @@ func TestGetPlays_NoFilters(t *testing.T) {
 	mockClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		vars := args.Get(2).(map[string]interface{})
 
+		q := args.Get(1).(*playQuery)
+		*q = mockResponse
+
 		// Check default play type is "ALL"
 		assert.Equal(t, PlayTypeAll, vars["playType"])
 
@@ -84,6 +87,9 @@ func TestGetPlays_WithFilters(t *testing.T) {
 	// Mock the query method for the GraphQL client
 	mockClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		vars := args.Get(2).(map[string]interface{})
+
+		q := args.Get(1).(*playQuery)
+		*q = mockResponse
 
 		// Check that the play type and filters are set correctly
 		assert.Equal(t, PlayTypeDeveloper, vars["playType"])
@@ -129,6 +135,9 @@ func TestGetPlays_WithPartialFilters(t *testing.T) {
 	mockClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		vars := args.Get(2).(map[string]interface{})
 
+		q := args.Get(1).(*playQuery)
+		*q = mockResponse
+
 		// Check default play type is applied
 		assert.Equal(t, PlayTypeAll, vars["playType"])
 
@@ -171,7 +180,7 @@ func TestGetPlays_Error(t *testing.T) {
 	mockClient.On("Query", mock.Anything, &playQuery{}, mock.Anything).Return(errors.New("graphql error"))
 
 	// Call the method
-	plays, totalItems, err := client.GetPlays(from, to, take, skip)
+	plays, totalItems, err := client.GetPlays(from, to, take, skip, nil)
 
 	// Assertions
 	assert.Error(t, err)

--- a/instruqt/user.go
+++ b/instruqt/user.go
@@ -29,6 +29,7 @@ type userInfoQuery struct {
 
 // User represents the data structure for an Instruqt user.
 type User struct {
+	Id      string
 	Details struct { // Detailed user information associated with a specific team.
 		FirstName graphql.String // The first name of the user.
 		LastName  graphql.String // The last name of the user.


### PR DESCRIPTION
This adds optional filters to the GetPlays() function

Sample usage:

```go
plays, total, err := instruqtClient.GetPlays(
	time.Now().AddDate(0, 0, -30), time.Now(),
	10, 0,
	instruqt.WithTrackIDs("abcdef"),
	instruqt.WithUserIDs("efjkelrg"),
	instruqt.WithPlayType(instruqt.PlayTypeNormal),
)
```


Signed-off-by: Raphaël Pinson <raphael@isovalent.com>
