### PR TITLE
Improve performance of Sandbox and Challenge queries

### DIFF
--- a/instruqt/challenge.go
+++ b/instruqt/challenge.go
@@ -63,8 +63,12 @@ func (c *Client) GetChallenge(id string, opts ...Option) (ch Challenge, err erro
 		return ch, nil
 	}
 
+	// Initialize the filter with default values
+	filters := &options{
+		includeAssignment: false,
+	}
+
 	// Apply each option to modify the filter
-	var filters *options
 	for _, opt := range opts {
 		opt(filters)
 	}
@@ -78,7 +82,7 @@ func (c *Client) GetChallenge(id string, opts ...Option) (ch Challenge, err erro
 		return ch, err
 	}
 
-	if filters != nil && filters.includeAssignment {
+	if filters.includeAssignment {
 		cc, err := c.GetChallengeWithAssignment(id)
 		if err != nil {
 			return ch, err
@@ -105,8 +109,12 @@ func (c *Client) GetUserChallenge(userId string, id string, opts ...Option) (ch 
 		return ch, nil
 	}
 
+	// Initialize the filter with default values
+	filters := &options{
+		includeAssignment: false,
+	}
+
 	// Apply each option to modify the filter
-	var filters *options
 	for _, opt := range opts {
 		opt(filters)
 	}
@@ -121,7 +129,7 @@ func (c *Client) GetUserChallenge(userId string, id string, opts ...Option) (ch 
 		return ch, err
 	}
 
-	if filters != nil && filters.includeAssignment {
+	if filters.includeAssignment {
 		cc, err := c.GetChallengeWithAssignment(id)
 		if err != nil {
 			return ch, err

--- a/instruqt/option.go
+++ b/instruqt/option.go
@@ -38,6 +38,10 @@ type options struct {
 	userIDs        []string
 	playType       PlayType
 	ordering       *Ordering
+
+	// Options for GetSandboxes
+	state   string
+	poolIDs []string
 }
 
 // WithPlay is a functional option that configures methods to include the 'play' field in the query.
@@ -101,6 +105,22 @@ func WithUserIDs(ids ...string) Option {
 func WithPlayType(pt PlayType) Option {
 	return func(opts *options) {
 		opts.playType = pt
+	}
+}
+
+// WithState sets the State filter for methods that support it.
+// Usage: GetSandboxes(WithState("active"))
+func WithState(state string) Option {
+	return func(opts *options) {
+		opts.state = state
+	}
+}
+
+// WithPoolIDs sets the PoolIDs filter for methods that support it.
+// Usage: GetSandboxes(WithPoolIDs("pool1", "pool2"))
+func WithPoolIDs(ids ...string) Option {
+	return func(opts *options) {
+		opts.poolIDs = ids
 	}
 }
 

--- a/instruqt/option.go
+++ b/instruqt/option.go
@@ -111,9 +111,9 @@ func WithPlayType(pt PlayType) Option {
 	}
 }
 
-// WithState sets the State filter for methods that support it.
+// WithStates sets the State filter for methods that support it.
 // Usage: GetSandboxes(WithState("active"))
-func WithState(states ...SandboxState) Option {
+func WithStates(states ...SandboxState) Option {
 	return func(opts *options) {
 		opts.states = states
 	}

--- a/instruqt/option.go
+++ b/instruqt/option.go
@@ -43,7 +43,7 @@ type options struct {
 	ordering       *Ordering
 
 	// Options for GetSandboxes
-	state   string
+	state   SandboxState
 	poolIDs []string
 }
 
@@ -113,7 +113,7 @@ func WithPlayType(pt PlayType) Option {
 
 // WithState sets the State filter for methods that support it.
 // Usage: GetSandboxes(WithState("active"))
-func WithState(state string) Option {
+func WithState(state SandboxState) Option {
 	return func(opts *options) {
 		opts.state = state
 	}

--- a/instruqt/option.go
+++ b/instruqt/option.go
@@ -43,7 +43,7 @@ type options struct {
 	ordering       *Ordering
 
 	// Options for GetSandboxes
-	state   SandboxState
+	states  []SandboxState
 	poolIDs []string
 }
 
@@ -113,9 +113,9 @@ func WithPlayType(pt PlayType) Option {
 
 // WithState sets the State filter for methods that support it.
 // Usage: GetSandboxes(WithState("active"))
-func WithState(state SandboxState) Option {
+func WithState(states ...SandboxState) Option {
 	return func(opts *options) {
-		opts.state = state
+		opts.states = states
 	}
 }
 

--- a/instruqt/option.go
+++ b/instruqt/option.go
@@ -30,6 +30,9 @@ type options struct {
 	includeChallenges bool
 	includeReviews    bool
 
+	// Options for GetChallenge*
+	includeAssignment bool
+
 	// Options for GetPlays
 	trackIDs       []string
 	trackInviteIDs []string
@@ -121,6 +124,12 @@ func WithState(state string) Option {
 func WithPoolIDs(ids ...string) Option {
 	return func(opts *options) {
 		opts.poolIDs = ids
+	}
+}
+
+func WithAssignment() Option {
+	return func(opts *options) {
+		opts.includeAssignment = true
 	}
 }
 

--- a/instruqt/sandbox.go
+++ b/instruqt/sandbox.go
@@ -125,23 +125,6 @@ func (c *Client) GetSandbox(id string, opts ...Option) (s Sandbox, err error) {
 		return s, err
 	}
 
-	if filters.includeChallenges {
-		challenges, err := c.GetChallenges(q.Sandbox.Track.Id)
-		if err != nil {
-			return s, err
-		}
-
-		// Enrich challenges with status
-		for i := range challenges {
-			if ch, err := c.GetUserChallenge(q.Sandbox.User.Id, challenges[i].Id); err == nil {
-				challenges[i] = ch
-			} else {
-				return s, err
-			}
-		}
-		q.Sandbox.Track.Challenges = challenges
-	}
-
 	return q.Sandbox, nil
 }
 
@@ -183,17 +166,6 @@ func (c *Client) GetSandboxes(opts ...Option) (s []Sandbox, err error) {
 
 	if err := c.GraphQLClient.Query(c.Context, &q, variables); err != nil {
 		return s, err
-	}
-
-	if filters.includeChallenges {
-		for i := range q.Sandboxes.Nodes {
-			sandbox := q.Sandboxes.Nodes[i]
-			t, err := c.GetUserTrackById(sandbox.User.Id, sandbox.Track.Id, WithChallenges())
-			if err != nil {
-				return s, err
-			}
-			q.Sandboxes.Nodes[i].Track = t
-		}
 	}
 
 	return q.Sandboxes.Nodes, nil

--- a/instruqt/sandbox.go
+++ b/instruqt/sandbox.go
@@ -170,7 +170,7 @@ func (c *Client) GetSandboxes(opts ...Option) (s []Sandbox, err error) {
 		queryFilter.Pool_ids = filters.poolIDs
 	}
 	if filters.state != "" {
-		queryFilter.State = SandboxState(filters.state)
+		queryFilter.State = filters.state
 	}
 
 	var q sandboxesQuery

--- a/instruqt/sandbox.go
+++ b/instruqt/sandbox.go
@@ -176,7 +176,7 @@ func (c *Client) GetSandboxes(opts ...Option) (s []Sandbox, err error) {
 		"invite_ids":      trackInviteIds,
 		"pool_ids":        poolIds,
 		"user_name_or_id": graphql.String(userNameOrId),
-		"state":           filters.state,
+		"state":           filters.states,
 	}
 
 	if err := c.GraphQLClient.Query(c.Context, &q, variables); err != nil {

--- a/instruqt/sandbox.go
+++ b/instruqt/sandbox.go
@@ -37,7 +37,22 @@ type sandboxQuery struct {
 	Sandbox Sandbox `graphql:"sandbox(ID: $id)"`
 }
 
-// sandboxesQuery represents the GraphQL query structure for retrieving all sandboxes
+// SandboxState defines the possible states of a sandbox.
+type SandboxState string
+
+// Constants representing different sandbox states.
+const (
+	SandboxStateCreating SandboxState = "creating"
+	SandboxStateCreated  SandboxState = "created"
+	SandboxStateFailed   SandboxState = "failed"
+	SandboxStatePooled   SandboxState = "pooled"
+	SandboxStateStopped  SandboxState = "stopped"
+	SandboxStateActive   SandboxState = "active"
+	SandboxStateClaimed  SandboxState = "claimed"
+	SandboxStateCleaning SandboxState = "cleaning"
+	SandboxStateCleaned  SandboxState = "cleaned"
+)
+
 // associated with a specific team.
 type sandboxesQuery struct {
 	Sandboxes struct {
@@ -47,13 +62,13 @@ type sandboxesQuery struct {
 
 // sandboxFilterInput represents the filter options for querying sandboxes.
 type SandboxFilterInput struct {
-	Track_ids       []string  // A list of track IDs to filter sandboxes.
-	Invite_ids      []string  // A list of invite IDs to filter sandboxes.
-	Pool_ids        []string  // A list of hot start pool IDs to filter sandboxes.
-	User_name_or_id string    // The user name or id
-	State           string    // The state of the sandbox (e.g., "active", "inactive").
-	From            time.Time // The start time for the sandbox filter.
-	To              time.Time // The end time for the sandbox filter.
+	Track_ids       []string     // A list of track IDs to filter sandboxes.
+	Invite_ids      []string     // A list of invite IDs to filter sandboxes.
+	Pool_ids        []string     // A list of hot start pool IDs to filter sandboxes.
+	User_name_or_id string       // The user name or id
+	State           SandboxState // The state of the sandbox (e.g., "active", "inactive").
+	From            time.Time    // The start time for the sandbox filter.
+	To              time.Time    // The end time for the sandbox filter.
 }
 
 // Sandbox represents a sandbox environment within Instruqt, including details
@@ -155,7 +170,7 @@ func (c *Client) GetSandboxes(opts ...Option) (s []Sandbox, err error) {
 		queryFilter.Pool_ids = filters.poolIDs
 	}
 	if filters.state != "" {
-		queryFilter.State = filters.state
+		queryFilter.State = SandboxState(filters.state)
 	}
 
 	var q sandboxesQuery

--- a/instruqt/sandbox.go
+++ b/instruqt/sandbox.go
@@ -187,20 +187,12 @@ func (c *Client) GetSandboxes(opts ...Option) (s []Sandbox, err error) {
 
 	if filters.includeChallenges {
 		for i := range q.Sandboxes.Nodes {
-			challenges, err := c.GetChallenges(q.Sandboxes.Nodes[i].Track.Id)
+			sandbox := q.Sandboxes.Nodes[i]
+			t, err := c.GetUserTrackById(sandbox.User.Id, sandbox.Track.Id, WithChallenges())
 			if err != nil {
 				return s, err
 			}
-
-			// Enrich challenges with status
-			for j := range challenges {
-				if ch, err := c.GetUserChallenge(q.Sandboxes.Nodes[i].User.Id, challenges[j].Id); err == nil {
-					challenges[j] = ch
-				} else {
-					return s, err
-				}
-			}
-			q.Sandboxes.Nodes[i].Track.Challenges = challenges
+			q.Sandboxes.Nodes[i].Track = t
 		}
 	}
 

--- a/instruqt/track.go
+++ b/instruqt/track.go
@@ -96,7 +96,7 @@ type SandboxTrack struct {
 		TotalCount int
 		Nodes      []Review
 	} `graphql:"-"` /* Not queried */
-	Challenges  []Challenge `graphql:"-"` // A list of challenges associated with the sandbox track, not queried.
+	Challenges  []Challenge // A list of challenges associated with the sandbox track, not queried.
 	Status      string      // The current status of the sandbox track.
 	Started     time.Time   // The timestamp when the sandbox track was started.
 	Completed   time.Time   // The timestamp when the sandbox track was completed.


### PR DESCRIPTION
Breaking changes:
- assignment not included in challenges by default (requires `WithAssignment()`)
- challenges included in SandboxTracks again (like they used to be)