### PR TITLE
Preserve user context for parsed challenge assignments

### DIFF
--- a/instruqt/challenge.go
+++ b/instruqt/challenge.go
@@ -131,7 +131,7 @@ func (c *Client) GetUserChallenge(userId string, id string, opts ...Option) (ch 
 	}
 
 	if filters.includeAssignment {
-		cc, err := c.GetChallengeWithAssignment(id, filters.parseAssignmentVariables)
+		cc, err := c.GetUserChallengeWithAssignment(userId, id, filters.parseAssignmentVariables)
 		if err != nil {
 			return ch, err
 		}
@@ -163,6 +163,33 @@ func (c *Client) GetChallengeWithAssignment(id string, parseAssignmentVariables 
 	}
 	variables := map[string]interface{}{
 		"challengeId":              graphql.String(id),
+		"parseAssignmentVariables": graphql.Boolean(parseVariables),
+	}
+
+	if err := c.GraphQLClient.Query(c.Context, &q, variables); err != nil {
+		return ch, err
+	}
+
+	return q.Challenge, nil
+}
+
+// GetUserChallengeWithAssignment returns a ChallengeWithAssignment scoped to a user.
+func (c *Client) GetUserChallengeWithAssignment(userId string, id string, parseAssignmentVariables ...bool) (ch ChallengeWithAssignment, err error) {
+	if id == "" {
+		return ch, nil
+	}
+
+	parseVariables := false
+	if len(parseAssignmentVariables) > 0 {
+		parseVariables = parseAssignmentVariables[0]
+	}
+
+	var q struct {
+		Challenge ChallengeWithAssignment `graphql:"challenge(userID: $userId, challengeID: $challengeId)"`
+	}
+	variables := map[string]interface{}{
+		"challengeId":              graphql.String(id),
+		"userId":                   graphql.String(userId),
 		"parseAssignmentVariables": graphql.Boolean(parseVariables),
 	}
 

--- a/instruqt/challenge_test.go
+++ b/instruqt/challenge_test.go
@@ -108,6 +108,79 @@ func TestGetChallengeWithAssignmentParseAssignmentVariables(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestGetUserChallengeWithAssignmentParseAssignmentVariables(t *testing.T) {
+	mockClient := new(MockGraphQLClient)
+	client := &Client{
+		GraphQLClient: mockClient,
+	}
+
+	userID := "user-123"
+	challengeID := "challenge-123"
+
+	mockClient.On("Query", mock.Anything, mock.Anything, mock.MatchedBy(func(vars map[string]any) bool {
+		parse, ok := vars["parseAssignmentVariables"].(graphql.Boolean)
+		if !ok || !bool(parse) {
+			return false
+		}
+		return vars["challengeId"] == graphql.String(challengeID) &&
+			vars["userId"] == graphql.String(userID)
+	})).Return(nil)
+
+	_, err := client.GetUserChallengeWithAssignment(userID, challengeID, true)
+
+	assert.NoError(t, err)
+	mockClient.AssertExpectations(t)
+}
+
+func TestGetUserChallengeWithParsedAssignmentVariablesUsesUserContext(t *testing.T) {
+	mockClient := new(MockGraphQLClient)
+	client := &Client{
+		GraphQLClient: mockClient,
+	}
+
+	userID := "user-123"
+	challengeID := "challenge-123"
+	expectedChallenge := Challenge{
+		Id:     "challenge-123",
+		Slug:   "test-slug",
+		Title:  "Test Challenge",
+		Index:  1,
+		Status: "completed",
+	}
+
+	queryResult := userChallengeQuery{
+		Challenge: expectedChallenge,
+	}
+
+	mockClient.On("Query", mock.Anything, &userChallengeQuery{}, mock.Anything).Run(func(args mock.Arguments) {
+		q := args.Get(1).(*userChallengeQuery)
+		*q = queryResult
+	}).Return(nil)
+
+	mockClient.On("Query", mock.Anything, mock.Anything, mock.MatchedBy(func(vars map[string]any) bool {
+		parse, ok := vars["parseAssignmentVariables"].(graphql.Boolean)
+		if !ok || !bool(parse) {
+			return false
+		}
+		return vars["challengeId"] == graphql.String(challengeID) &&
+			vars["userId"] == graphql.String(userID)
+	})).Run(func(args mock.Arguments) {
+		q := args.Get(1).(*struct {
+			Challenge ChallengeWithAssignment `graphql:"challenge(userID: $userId, challengeID: $challengeId)"`
+		})
+		q.Challenge = ChallengeWithAssignment{
+			Id:         challengeID,
+			Assignment: "parsed assignment",
+		}
+	}).Return(nil)
+
+	challenge, err := client.GetUserChallenge(userID, challengeID, WithParsedAssignmentVariables())
+
+	assert.NoError(t, err)
+	assert.Equal(t, "parsed assignment", challenge.Assignment)
+	mockClient.AssertExpectations(t)
+}
+
 func TestSkipToChallenge(t *testing.T) {
 	mockClient := new(MockGraphQLClient)
 	client := &Client{


### PR DESCRIPTION
## What changed

- Added a user-scoped challenge assignment query helper.
- Updated GetUserChallenge(..., WithParsedAssignmentVariables()) to fetch assignment text with userID + challengeID instead of falling back to the public challenge query.
- Added tests covering parsed assignment variables and user-scoped assignment fetching.

## Why

The parsed assignment path needs user context for runtime variable interpolation. Calling GetChallengeWithAssignment() from GetUserChallenge() dropped that context, so parseAssignmentVariables was effectively moot for user sessions.

## Validation

- go test ./...